### PR TITLE
Update dependabot to group patches in a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,14 @@ updates:
           - 'danieljancar'
       labels:
           - 'dependencies'
-      milestone: 2
       ignore:
           - dependency-name: '*'
             update-types:
                 - 'version-update:semver-major'
                 - 'version-update:semver-minor'
+      groups:
+          patch-updates:
+              patterns:
+                  - '*'
+              update-types:
+                  - 'patch'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
           - 'danieljancar'
       labels:
           - 'dependencies'
+      milestone: 2
       ignore:
           - dependency-name: '*'
             update-types:


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` file to introduce a new grouping for dependency updates. The change aims to better organize and manage updates by separating patch updates into their own group.

Dependency management improvements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R25-R30): Added a new group named `patch-updates` with a pattern matching all dependencies (`'*'`) and restricted it to only handle `patch` update types.