### PR TITLE
chore: add permissions to workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,5 +1,8 @@
 name: Backend CI
 
+permissions:
+    contents: read
+
 on:
     push:
         paths:

--- a/.github/workflows/dev-deployment.yml
+++ b/.github/workflows/dev-deployment.yml
@@ -1,5 +1,8 @@
 name: Deploy development (Backend & Frontend)
 
+permissions:
+    contents: read
+
 on:
     push:
         branches: [develop]

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,5 +1,8 @@
 name: Frontend CI
 
+permissions:
+    contents: read
+
 on:
     push:
         paths:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -15,6 +15,6 @@ jobs:
             - uses: actions/labeler@v4
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
-                  sync-labels: true
+                  sync-labels: 'true'
                   dot: true
                   configuration-path: .github/labeler.yml

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,5 +1,8 @@
 name: Prettier
 
+permissions:
+    contents: read
+
 on:
     pull_request:
     push:


### PR DESCRIPTION
This pull request introduces updates to several GitHub Actions workflows to enhance security and ensure proper configuration. The main changes include adding `permissions` settings to workflows for least-privilege access and updating a parameter in the `label-pr` workflow to ensure correct syntax.

### Security improvements:

* Added `permissions` settings with `contents: read` to the following workflows to enforce least-privilege access:
  - `.github/workflows/backend.yml`
  - `.github/workflows/dev-deployment.yml`
  - `.github/workflows/frontend.yml`
  - `.github/workflows/prettier.yml`

### Workflow configuration:

* Updated the `sync-labels` parameter in `.github/workflows/label-pr.yml` to use a string value (`'true'`) for proper syntax.