### PR TITLE
Add device-id header to frontend requests

### DIFF
--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -2,14 +2,15 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core'
 import { provideRouter } from '@angular/router'
 
 import { routes } from './app.routes'
-import { provideHttpClient } from '@angular/common/http'
+import { provideHttpClient, withInterceptors } from '@angular/common/http'
 import { provideMarkdown } from 'ngx-markdown'
+import { deviceIdInterceptor } from './core/device-id.interceptor'
 
 export const appConfig: ApplicationConfig = {
     providers: [
         provideZoneChangeDetection({ eventCoalescing: true }),
         provideRouter(routes),
-        provideHttpClient(),
+        provideHttpClient(withInterceptors([deviceIdInterceptor])),
         provideMarkdown(),
     ],
 }

--- a/apps/frontend/src/app/common/storage.constants.ts
+++ b/apps/frontend/src/app/common/storage.constants.ts
@@ -4,11 +4,14 @@ export const LOCAL_STORAGE_KEYS = {
     UI_STATE: {
         HIDE_LANDING: 'hide_landing',
     },
+    DEVICE: {
+        ID: 'device_id',
+    },
 } as const
 
 export type FlatLocalStorageKey =
-    (typeof LOCAL_STORAGE_KEYS.UI_STATE)[keyof typeof LOCAL_STORAGE_KEYS.UI_STATE]
-
+    | (typeof LOCAL_STORAGE_KEYS.UI_STATE)[keyof typeof LOCAL_STORAGE_KEYS.UI_STATE]
+    | (typeof LOCAL_STORAGE_KEYS.DEVICE)[keyof typeof LOCAL_STORAGE_KEYS.DEVICE]
 export interface ExpiringLocalStorageValue<T> {
     value: T
     expiresAt: number // timestamp

--- a/apps/frontend/src/app/core/device-id.interceptor.ts
+++ b/apps/frontend/src/app/core/device-id.interceptor.ts
@@ -1,0 +1,11 @@
+import { HttpInterceptorFn } from '@angular/common/http'
+import { inject } from '@angular/core'
+import { DeviceIdService } from './device-id.service'
+
+export const deviceIdInterceptor: HttpInterceptorFn = (req, next) => {
+    const deviceId = inject(DeviceIdService).id
+    const cloned = req.clone({
+        headers: req.headers.set('x-device-id', deviceId),
+    })
+    return next(cloned)
+}

--- a/apps/frontend/src/app/core/device-id.service.ts
+++ b/apps/frontend/src/app/core/device-id.service.ts
@@ -1,0 +1,32 @@
+import { inject, Injectable } from '@angular/core'
+import { LocalStorageService } from '../utils/local-storage.service'
+import { LOCAL_STORAGE_KEYS } from '../common/storage.constants'
+
+@Injectable({
+    providedIn: 'root',
+})
+export class DeviceIdService {
+    #localStorage = inject(LocalStorageService)
+    #key = LOCAL_STORAGE_KEYS.DEVICE.ID
+    #deviceId = this.#localStorage.get<string>(this.#key)
+
+    constructor() {
+        if (!this.#deviceId) {
+            this.#deviceId = this.generateId()
+            this.#localStorage.set(this.#key, this.#deviceId)
+        }
+    }
+
+    get id(): string {
+        return this.#deviceId!
+    }
+
+    private generateId(): string {
+        if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+            return crypto.randomUUID()
+        }
+        return `${Date.now().toString(36)}-${Math.random()
+            .toString(36)
+            .substring(2, 9)}`
+    }
+}


### PR DESCRIPTION
## Summary
- persist device id in local storage
- add HTTP interceptor to attach `x-device-id` header
- register interceptor in app configuration

## Testing
- `npm run lint:frontend`
